### PR TITLE
Adds March 13 notes, makes Show&Tell optional

### DIFF
--- a/meta/show_and_tell.md
+++ b/meta/show_and_tell.md
@@ -1,6 +1,6 @@
 # Show & Tell
 
-Show & Tell is a new weekly event we're trying out to get more visibility into what our teammates have been working on recently. It is scheduled weekly for a half hour each week (see the shared Engineering Open Meetings calendar) and consists of three ten-minute walkthroughs. These walkthroughs are a presentation of works-in-progress and *no* preparation is expected of these presenters. We get people excited about Show & Tell at [Monday standups](open_standup.md) and then do an *@here* an hour beforehand to remind people. We then meet and, in an open mic-style, developers step forward to show and tell!
+Show & Tell is a new, **optional** weekly event we're trying out to get more visibility into what our teammates have been working on recently. It is scheduled weekly for a half hour each week (see the shared Engineering Open Meetings calendar) and consists of three ten-minute walkthroughs. These walkthroughs are a presentation of works-in-progress and *no* preparation is expected of these presenters. We get people excited about Show & Tell at [Monday standups](open_standup.md) and then do an *@here* an hour beforehand to remind people. We then meet and, in an open mic-style, developers step forward to show and tell!
 
 Previous demos include:
 

--- a/meta/show_and_tell.md
+++ b/meta/show_and_tell.md
@@ -6,8 +6,14 @@ Previous demos include:
 
 - Cool things with [Cypress](https://www.cypress.io) and [Mapbox](https://www.mapbox.com) by [@anandaroop][roop].
 - Initial work on the new [CocoaPods metadata service](https://github.com/CocoaPods/cocoapods-metadata-service) by [@orta][orta].
+- Experimenting with [Rails+React+TypeScript](https://github.com/jonallured/update_queue) with [@jonallured][jon].
+- Preview of [Building Better Software by Building Better Teams](http://appdevcon.nl/session/building-better-software-by-building-better-teams/) by [@ashfurrow][ash].
+- Experimenting with [Isomorphic Relay](https://github.com/damassi/isomorphic-relay-app) by [@damassi][chris].
 
 It's still early in the process so we're looking forward to how this event can grow and encourage cross-team collaboration and knowledge sharing.
 
 [orta]: https://github.com/orta
 [roop]: https://github.com/anandaroop
+[chris]: https://github.com/damassi
+[jon]: https://github.com/jonallured
+[ash]: https://github.com/ashfurrow


### PR DESCRIPTION
This adds the three things we saw today, as well as marks the meeting as **optional** by our engineers.