### PR TITLE
Add on-call support section to meeting notes template

### DIFF
--- a/meta/open_standup.md
+++ b/meta/open_standup.md
@@ -19,6 +19,7 @@ A standup is ideally ran by two people, one person talking, the other taking not
 * We start off with props, as a nod towards [People are Paramount][pplp]
 * Then we get an update from the CTO
 * Then an update from the Product team
+* Then an update from the current on-call support team
 * Each tech lead gives a summary of what their teams have been up to
   * If the stand-up is straight after sprint kickoff, skip this section and thank people for giving their demos
   * You can get the projects from the [Sprint Kickoff][sk] google sheet
@@ -41,6 +42,10 @@ _CTO Update_
 -
 
 _Product Team Updates_
+
+-
+
+_On-call Support Updates_
 
 -
 


### PR DESCRIPTION
Simply adds on-call support to the meeting agenda/notes.