### PR TITLE
Adds notes for support staff

### DIFF
--- a/meta/open_standup.md
+++ b/meta/open_standup.md
@@ -14,6 +14,10 @@ sharing; they are an organization-wide responsibility and every engineer should 
 
 * The person handling the talking parts `@here`s the dev channel. Include where the meeting is in the NYC office
   (usually the Classroom).
+* The same person reminds last week's on-call staff in #dev to prepare their updates about last week's rotation. Something like:
+
+> @personA @personB reminder, we're looking for a list of major or notable incidents from last week during standup.
+
 * The same person reminds the team leads in #dev to prepare their tweet-sized updates, something like this:
 
 > friendly reminder: we’re doing summary updates from tech leads during open standup, so have yours ready! /cc

--- a/meta/open_standup.md
+++ b/meta/open_standup.md
@@ -15,13 +15,10 @@ sharing; they are an organization-wide responsibility and every engineer should 
 * The person handling the talking parts `@here`s the dev channel. Include where the meeting is in the NYC office
   (usually the Classroom).
 * The same person reminds last week's on-call staff in #dev to prepare their updates about last week's rotation. Something like:
-
-> @personA @personB reminder, we're looking for a list of major or notable incidents from last week during standup.
-
+  > @personA @personB reminder, we're looking for a list of major or notable incidents from last week during standup.
 * The same person reminds the team leads in #dev to prepare their tweet-sized updates, something like this:
-
-> friendly reminder: we’re doing summary updates from tech leads during open standup, so have yours ready! /cc
-> @tech-leads
+  > friendly reminder: we’re doing summary updates from tech leads during open standup, so have yours ready! 
+  > /cc @tech-leads
 
 ### What is a good update?
 

--- a/meta/open_standup.md
+++ b/meta/open_standup.md
@@ -12,6 +12,7 @@ sharing; they are an organization-wide responsibility and every engineer should 
 
 ### Ten minutes before a standup
 
+* The person handling the talking parts should check [the on-call calendar](https://calendar.google.com/calendar/embed?src=artsymail.com_nolej2muchgbpne9etkf7qfet8%40group.calendar.google.com&ctz=America%2FNew_York) to see who is on call this week. They will remind everyone who it is during the standup, included in the template below.
 * The person handling the talking parts `@here`s the dev channel. Include where the meeting is in the NYC office
   (usually the Classroom).
 * The same person reminds last week's on-call staff in #dev to prepare their updates about last week's rotation. Something like:
@@ -57,6 +58,7 @@ _Product Team Updates_
 
 _On-call Support Updates_
 
+- This week, @personC and @personD will be on-call for support.
 -
 
 _Team Updates_


### PR DESCRIPTION
In today's standup, @dblock had the suggestion that standup updates should be more structured. I've defined that as "a list of major or notable incidents from last week", but it's totally up for discussion. This PR adds that note and updates the indentation of the list for readability.