### PR TITLE
Removes product team updates

### DIFF
--- a/meta/open_standup.md
+++ b/meta/open_standup.md
@@ -50,10 +50,6 @@ _CTO Update_
 
 -
 
-_Product Team Updates_
-
--
-
 _On-call Support Updates_
 
 -


### PR DESCRIPTION
Since the engineering and product teams are now in much closer communication, we don't need this in our standup. And indeed, we haven't had any updates from product in a month or so, so this PR just brings the docs into line with our existing practices.