### PR TITLE
Clarifies audience for L&L's.

### DIFF
--- a/meta/lunch_and_learn.md
+++ b/meta/lunch_and_learn.md
@@ -1,12 +1,18 @@
 # Lunch & Learn
 
-When Artsy was under 50 people, we would hold "Brown Bag" meetings. These were talks on a variety of art+science topics. As we out-grew the format, we started doing engineering "Brown Bag" meetings. Occasionally.
+When Artsy was under 50 people, we would hold "Brown Bag" meetings. These were talks on a variety of art+science topics. Sometimes they had a very general audience and sometimes they had a deeply technical audience. As we've grown, we've grown that concept into Lunch & Learns.
 
-This worked for a while, but was sporadic and mostly the same speakers. Once we moved to [a new stand-up format](http://artsy.github.io/blog/2015/03/23/artsy-technology-stack-2015/) it felt like time to re-vamp our brown bags too.
+## Format & Audience
 
-Our format is pretty simple, every Thursday we have an hour slot at 12 (NYC time) on the calendar for someone to give a talk or presentation. I think [Alan](http://twitter.com/alanjay1/) described it well on [Professional Development at Artsy](http://artsy.github.io/blog/2016/09/22/professional-development-at-artsy-engineering/):
+Our format is pretty simple, every Thursday we have an hour slot at 12 (NYC time) on the calendar for someone to give a talk or presentation. [Alan](http://twitter.com/alanjay1/) described it well on [Professional Development at Artsy](http://artsy.github.io/blog/2016/09/22/professional-development-at-artsy-engineering/):
 
 > Every Thursday, we do a Lunch-and-Learn session. Historically, we mostly showed off tech we use internally. But over about a year, most of our tech stack has been presented this way, so we also bring in engineers we know at other companies to share what they’re working on.
+
+The format is definitely not set in stone, however these are what has worked for us internally and for past contributors.
+
+The **audience** of the Lunch & Learns spans from just our engineering team all the way up to the entire company. Each Lunch & Learn is different. When promoting the Lunch & Learns internally (in staff newsletters and calendar invitations), we try to clarify who the audience is for that specific talk. This gives us the flexibility to have talks like "How to Automate Docker Deploys" and also "How to Build Effective Business Teams" in the same series of talks.
+
+## Contributors
 
 So far, from external contributors we've had:
 
@@ -31,10 +37,6 @@ So far, from external contributors we've had:
 
 You're probably seeing this as an external developer to Artsy, who has been invited to talk.
 
-## Format
-
-The format is definitely not set in stone, however these are what has worked for us internally and for past contributors.
-
 #### Presentation
 
 Traditional conference/meetup style: You bring slides, we watch. You talk, we listen. You finish, we ask questions.
@@ -47,7 +49,7 @@ More informal, you can come with other speakers and talk about the ways in which
 
 ## Schedule
 
-* Arrive at Artsy for 11:45am ( We're [401 Broadway, 26th Floor, 10013][401] - Canal St is the closest station)
+* Arrive at Artsy for 11:45am (we're [401 Broadway, 26th Floor, 10013][401] - Canal St is the closest station)
 * Our receptionist will get in touch with whoever you've been in contact with, probably [Orta] or [Ash]
 * They will get you set up on our 27th floor Classroom
 * We will set up [a stream](#recording) for global developers and slides
@@ -60,11 +62,9 @@ Artsy Engineering now owes you, and your company [a talk back](https://speakerde
 
 ## Recording
 
-We ask that we can share a livestream of your talk, because we have a lot of [global developers](https://www.artsy.net/article/eloy-duran-going-global-5-tips-to-make-remote-work). This is just loading a Zoom.us link on your computer and sharing your screen.
+We ask that we can share a livestream of your talk, because we have a lot of [global developers](https://www.artsy.net/article/eloy-duran-going-global-5-tips-to-make-remote-work). This is just loading a Zoom.us link on your computer and sharing your screen. We'd like to get a copy of your slides, too. Of course, we're happy to send you a copy of the recording.
 
-We also ask that we get a screen recording of your talk, just internally, for colleagues who couldn't attend or want to review your awesome talk later. This is also done through Zoom.us. We'd like to get a copy of your slides, too. Of course, we're happy to send you a copy of the recording.
-
-If you don't want to be recorded, we understand that you might talk and show things that are not for public consumption. We can skip the screen recording. We will not share anything externally without your express opinion.
+If you don't want to be recorded, we understand that you might talk and show things that are private. We can skip the screen recording. We will not share anything externally without your express opinion.
 
 [orta]: https://github.com/orta
 [ash]: https://github.com/ashfurrow

--- a/meta/lunch_and_learn.md
+++ b/meta/lunch_and_learn.md
@@ -35,7 +35,9 @@ So far, from external contributors we've had:
 
 ---
 
-You're probably seeing this as an external developer to Artsy, who has been invited to talk.
+## Giving a Talk
+
+You're probably seeing this as someone external to Artsy, who has been invited to talk. Please note that nothing about this format is set in stone; we are happy to work with you to figure out a format that works for you and your talk.
 
 #### Presentation
 
@@ -47,7 +49,7 @@ We don't expect conference/meetup-level presentation or practice. A lack of poli
 
 More informal, you can come with other speakers and talk about the ways in which your company works. Covering your tech stack, the decisions behind them. With the presentation mainly being a series of demos, and showing code architecture.
 
-## Schedule
+### Schedule
 
 * Arrive at Artsy for 11:45am (we're [401 Broadway, 26th Floor, 10013][401] - Canal St is the closest station)
 * Our receptionist will get in touch with whoever you've been in contact with, probably [Orta] or [Ash]
@@ -60,7 +62,7 @@ More informal, you can come with other speakers and talk about the ways in which
 
 Artsy Engineering now owes you, and your company [a talk back](https://speakerdeck.com/ashfurrow/teaching-and-learning-1). Feel free to arrange that whenever you like.
 
-## Recording
+### Recording
 
 We ask that we can share a livestream of your talk, because we have a lot of [global developers](https://www.artsy.net/article/eloy-duran-going-global-5-tips-to-make-remote-work). This is just loading a Zoom.us link on your computer and sharing your screen. We'd like to get a copy of your slides, too. Of course, we're happy to send you a copy of the recording.
 

--- a/meta/running_lunch_and_learn.md
+++ b/meta/running_lunch_and_learn.md
@@ -24,7 +24,8 @@ Sometimes you'll get an introduction to a speaker from a colleague, passing the 
 
 ### The Monday Before
 
-* Send a note to Camille and Katherine to be included in the weekly newsletter.
+* Send a note to Camille and Katherine to be included in the weekly newsletter. Make sure that the newsletter copy makes it clear who the audience is for the talk: is it a highly technical audience? Or more general?
+* If the audience for a talk is general enough to invite the whole company, then send out a calendar invitation. Make it clear who the audience is for the talk.
 * Make some noise on Slack to get folks excited to come on Thursday.
 
 ### The Day Before


### PR DESCRIPTION
I was talking with a non-engineering colleague in the PDDE org and they mentioned how unclear they are about who L&L's are for. I talked this over with @orta and we both agreed that we want to continue L&L's as we have done (sometimes deeply technical topics, sometimes topics for a general audience). Instead, let's address the concerns of our colleagues directly by changing how we communicate L&L's internally.

This pull request changes our L&L documentation to provide clarity around:

- how L&L's generally have an ill-defined audience, but...
- individual L&L's should have their audience defined within Artsy staff newsletters and calendar invitations.

It also cleans the docs up a little bit.

This is a WIP until I can get some feedback from colleagues in PDDE.