### PR TITLE
Add a step for showing RFCs in the standup?

### DIFF
--- a/meta/open_standup.md
+++ b/meta/open_standup.md
@@ -78,6 +78,10 @@ _New Milestones / Repos / Blog posts_
 
 -
 
+_Current team-wide RFCs_
+
+-
+
 _Lunch & Learn_
 
 -


### PR DESCRIPTION
https://github.com/artsy/potential/issues/170 talks about editing / removing the team leads discussion. Right now I try to remember to add the active RFCs in the last announcements section, but maybe that' can just be specific?